### PR TITLE
Remove extra assignment

### DIFF
--- a/src/Player/States/Move.gd
+++ b/src/Player/States/Move.gd
@@ -70,9 +70,7 @@ func calculate_velocity(
 		move_direction: Vector3,
 		delta: float
 	) -> Vector3:
-		var velocity_new: = velocity_current
-
-		velocity_new = move_direction * move_speed
+		var velocity_new := move_direction * move_speed
 		if velocity_new.length() > max_speed:
 			velocity_new = velocity_new.normalized() * max_speed
 		velocity_new.y = velocity_current.y + gravity * delta


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


**Description:**

Hi! Thanks for this project. I analyzed your code and noticed that `velocity_new` is assigned first to the `velocity_current`, and then  immediately reassigned to `move_direction * move_speed`. I suppose this is mistake. In this PR, I just removed the extra assignment. Maybe interpolation should have been called here for smooth movement?